### PR TITLE
[HOTFIX] consertado testes quebrados

### DIFF
--- a/backend/src/main/java/br/gov/sp/fatec/backend/models/Conversation.java
+++ b/backend/src/main/java/br/gov/sp/fatec/backend/models/Conversation.java
@@ -1,6 +1,8 @@
 package br.gov.sp.fatec.backend.models;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Table;
@@ -32,7 +34,7 @@ public class Conversation {
     private List<Message> messages;
 
     @ManyToMany(mappedBy = "conversations")
-    private List<Member> members;
+    private Set<Member> members = new HashSet<Member>();
 
     public long getId() {
         return id;
@@ -46,7 +48,7 @@ public class Conversation {
         return messages;
     }
 
-    public List<Member> getMembers() {
+    public Set<Member> getMembers() {
         return members;
     }
 

--- a/backend/src/main/java/br/gov/sp/fatec/backend/models/Member.java
+++ b/backend/src/main/java/br/gov/sp/fatec/backend/models/Member.java
@@ -1,6 +1,8 @@
 package br.gov.sp.fatec.backend.models;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Table;
@@ -30,14 +32,14 @@ public class Member {
     @Column(name = "member_name", nullable = false)
     private String name;
 
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = true)
     private Integer userId;
 
     @ManyToMany
     @JoinTable(name = "member_conversation",
                joinColumns = @JoinColumn(name = "conversation_id"),
                inverseJoinColumns = @JoinColumn(name = "member_id"))
-    private List<Conversation> conversations;
+    private Set<Conversation> conversations = new HashSet<Conversation>();
 
     @OneToMany(mappedBy = "sender")
     private List<Message> messages;
@@ -54,7 +56,7 @@ public class Member {
         return userId;
     }
 
-    public List<Conversation> getConversations() {
+    public Set<Conversation> getConversations() {
         return conversations;
     }
 

--- a/backend/src/main/java/br/gov/sp/fatec/backend/services/SecurityServiceImpl.java
+++ b/backend/src/main/java/br/gov/sp/fatec/backend/services/SecurityServiceImpl.java
@@ -18,69 +18,69 @@ import br.gov.sp.fatec.backend.repositories.MessageRepository;
 public class SecurityServiceImpl implements SecurityService {
 
     @Autowired
-    private ConversationRepository conversationRepo;
+    private ConversationRepository conversationRepository;
 
     @Autowired
-    private MessageRepository messageRepo;
+    private MessageRepository messageRepository;
 
     @Autowired
-    private MemberRepository memberRepo;
+    private MemberRepository memberRepository;
 
     @Transactional
-    public Message insertMessage(String text, Date timestamp, long conversation, long sender) {
-        Conversation conv = conversationRepo.findConversationById(conversation);
+    public Message insertMessage(String text, Date timestamp, long conversationId, long senderId) {
+        Conversation conversation = conversationRepository.findConversationById(conversationId);
 
-        if (conv == null) {
-            conv = new Conversation();
+        if (conversation == null) {
+            conversation = new Conversation();
+            conversation.setTitle("Conversation Test");
 
-            conv.setTitle("Conversation Test");
-            conversationRepo.save(conv);
+            conversationRepository.save(conversation);
         }
 
-        Member member = memberRepo.findMemberById(sender);
+        Member sender = memberRepository.findMemberById(senderId);
 
-        if (member == null) {
-            member = new Member();
-
-            member.setName("Member Test");
-            member.setUserId(2);
-            memberRepo.save(member);
+        if (sender == null) {
+            sender = new Member();
+            sender.setName("Member Test");
+            sender.setUserId(2);
+    
+            memberRepository.save(sender);
         }
 
         Message message = new Message();
 
-        message.setConversation(conv);
-        message.setSender(member);
+        message.setConversation(conversation);
+        message.setSender(sender);
         message.setText(text);
         message.setTimestamp(timestamp);
 
-        messageRepo.save(message);
+        messageRepository.save(message);
 
         return message;
     }
     
     @Transactional
-    public Member addToConversation(long id, long conversation) {
-        Conversation conv = conversationRepo.findConversationById(conversation);
+    public Member addToConversation(long memberId, long conversationId) {
+        Conversation conversation = conversationRepository.findConversationById(conversationId);
 
-        if (conv == null) {
-            conv = new Conversation();
+        if (conversation == null) {
+            conversation = new Conversation();
+            conversation.setTitle("Conversation Test");
 
-            conv.setTitle("Conversation Test");
-            conversationRepo.save(conv);
+            conversationRepository.save(conversation);
         }        
 
-        Member member = memberRepo.findMemberById(id);
+        Member member = memberRepository.findMemberById(memberId);
 
         if (member == null) {
             member = new Member();
-
-            member.setName("Member Test");
             member.setUserId(2);
-            memberRepo.save(member);
+            member.setName("Member Test");
+            
+            memberRepository.save(member);
         }
 
-        member.addConversation(conv);
+        conversation.addMember(member);
 
         return member;
     }

--- a/backend/src/test/java/br/gov/sp/fatec/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/br/gov/sp/fatec/backend/BackendApplicationTests.java
@@ -1,5 +1,6 @@
 package br.gov.sp.fatec.backend;
 
+import java.util.Calendar;
 import java.util.Date;
 
 import javax.transaction.Transactional;
@@ -29,28 +30,27 @@ import br.gov.sp.fatec.backend.services.SecurityService;
 class BackendApplicationTests {
 
     @Autowired
-    private ConversationRepository conversationRepo;
+    private ConversationRepository conversationRepository;
 
     @Autowired
-    private MessageRepository messageRepo;
+    private MessageRepository messageRepository;
 
     @Autowired
-    private MemberRepository memberRepo;
+    private MemberRepository memberRepository;
 
     @Autowired
     private SecurityService securityService;
 
 	@Test
-	void contextLoads() {
-    }
+	void contextLoads() {}
 
     @Order(1)
     @Test
     void insertConversation() {
         Conversation conversation = new Conversation();
-
         conversation.setTitle("Conversation 2");
-        conversationRepo.save(conversation);
+
+        conversationRepository.save(conversation);
 
         assertNotNull(conversation);
     }
@@ -60,10 +60,10 @@ class BackendApplicationTests {
     void insertMember() {
         Member member = new Member();
 
-        member.setName("Member 1");
         member.setUserId(1);
+        member.setName("Member 1");
 
-        memberRepo.save(member);
+        memberRepository.save(member);
 
         assertNotNull(member);
     }
@@ -71,9 +71,13 @@ class BackendApplicationTests {
     @Order(3)
     @Test
     void insertMessage() {
-        Date date = new Date(2020, 9, 22);
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2020, 9, 22);
+
+        Date date = calendar.getTime();
 
         Message message = securityService.insertMessage("Test", date, 1, 2);
+
         assertNotNull(message);
     }
 
@@ -88,7 +92,19 @@ class BackendApplicationTests {
     @Order(5)
     @Test
     void searchMessageByTextAndSender() {
-        Message messages = messageRepo.findByTextAndSender("Test", 2L);
-        assertNotNull(messages);
+        Member member = new Member();
+        member.setName("Eduardo");
+
+        memberRepository.save(member);
+
+        Message message = new Message();
+        message.setText("Test");
+        message.setSender(member);
+
+        messageRepository.save(message);
+
+        Message fetchedMessage = messageRepository.findByTextAndSender("Test", member.getId());
+
+        assertNotNull(fetchedMessage);
     }
 }


### PR DESCRIPTION
Haviam alguns testes que quebravam justamente por estarem a nível de transação de função e ao final de cada teste era executado um rollback. Então, os dados que um teste seguinte precisava já não existiam mais ao fim do teste anterior. Também foram renomeados nomes de variáveis para firarem mais expressivos.